### PR TITLE
Added support for wild-card selectors.

### DIFF
--- a/src/matchers/toHaveStyleRule.js
+++ b/src/matchers/toHaveStyleRule.js
@@ -69,8 +69,10 @@ const getCodeInMedia = (code, media) => {
   return getCodeBlock(trailingCode);
 };
 
+const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 const getStyleRule = (code, className, selector) => {
-  const styles = new RegExp(`${className}\\s*{([^}]*)`, 'g').exec(code);
+  const styles = new RegExp(`${escapeRegExp(className)}\\s*{([^}]*)`, 'g').exec(code);
   const capture = new RegExp(`(?:[^\\-]|^)${selector}\\s*:\\s*([^;]+)`, 'g');
 
   const matches = styles && styles[1].match(capture);

--- a/test/matchers/toHaveStyleRule.spec.js
+++ b/test/matchers/toHaveStyleRule.spec.js
@@ -15,6 +15,10 @@ const Button = styled.button`
     color: white;
   }
 
+  *:not([fill='none']) {
+    color: black;
+  }
+
   > span {
     color: green;
   }
@@ -107,6 +111,18 @@ describe('toHaveStyleRule', () => {
     expect(result.message).toEqual(getMessage({
       expected: 'white',
       received: 'white',
+      selector: 'color',
+    }));
+    expect(result.pass).toBeTruthy();
+
+    component = ReactTestRenderer.create(<Button />);
+    result = toHaveStyleRule({
+      component,
+      modifier: '*:not([fill=\'none\'])',
+    }, 'color', 'black');
+    expect(result.message).toEqual(getMessage({
+      expected: 'black',
+      received: 'black',
       selector: 'color',
     }));
     expect(result.pass).toBeTruthy();


### PR DESCRIPTION
Closes #11 

- [x] Pull request has tests / docs demo, and is linted.
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).
