### PR TITLE
Global escape media query to support multiple queries.

### DIFF
--- a/src/matchers/toHaveStyleRule.js
+++ b/src/matchers/toHaveStyleRule.js
@@ -59,8 +59,8 @@ const findClassName = (received) => {
 };
 
 const getCodeInMedia = (code, media) => {
-  const newMedia = media.replace('(', '\\(')
-    .replace(')', '\\)')
+  const newMedia = media.replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
     .replace(/\s/g, '\\s*');
   const mediaMatches = new RegExp(`@media\\s*${newMedia}\\s*{(.*)`).exec(code);
   const trailingCode = mediaMatches && mediaMatches[0];

--- a/test/matchers/toHaveStyleRule.spec.js
+++ b/test/matchers/toHaveStyleRule.spec.js
@@ -31,6 +31,12 @@ const Button = styled.button`
     color: black;
   }
 
+  @media screen and (max-width: 3800px) and (min-width: 601px) {
+    &:hover {
+      color: pink;
+    }
+  }
+
   @media screen and (max-width: 600px) {
     &:hover {
       color: purple;
@@ -287,7 +293,7 @@ describe('toHaveStyleRule', () => {
 
   test('should support string @media', () => {
     const component = ReactTestRenderer.create(<Button />);
-    const result = toHaveStyleRule({
+    let result = toHaveStyleRule({
       component,
       modifier: '&:hover',
       media: 'screen and (max-width: 600px)',
@@ -295,6 +301,18 @@ describe('toHaveStyleRule', () => {
     expect(result.message).toEqual(getMessage({
       expected: 'purple',
       received: 'purple',
+      selector: 'color',
+    }));
+    expect(result.pass).toBeTruthy();
+
+    result = toHaveStyleRule({
+      component,
+      modifier: '&:hover',
+      media: 'screen and (max-width: 3800px) and (min-width: 601px)',
+    }, 'color', 'pink');
+    expect(result.message).toEqual(getMessage({
+      expected: 'pink',
+      received: 'pink',
       selector: 'color',
     }));
     expect(result.pass).toBeTruthy();
@@ -339,7 +357,7 @@ describe('toHaveStyleRule', () => {
     }, 'color', 'purple');
     expect(result.message).toEqual(getMessage({
       expected: 'purple',
-      received: 'white',
+      received: 'pink',
       selector: 'color',
     }));
     expect(result.pass).toBeFalsy();


### PR DESCRIPTION
- [x] Pull request has tests / docs demo, and is linted.
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).

Closes https://github.com/mbasso/styled-components-test-utils/issues/14