### PR TITLE
Added regexp escape for object media.

### DIFF
--- a/src/matchers/toHaveStyleRule.js
+++ b/src/matchers/toHaveStyleRule.js
@@ -137,7 +137,7 @@ const toHaveStyleRule = (received, selector, expected) => {
       .map(x => getStyleRule(x, className, selector));
 
     const mediaMatches = values.length;
-    const classMatches = code.match(new RegExp(className, 'g'));
+    const classMatches = code.match(new RegExp(escapeRegExp(className), 'g'));
 
     if (mediaMatches < classMatches.length - 1) {
       // has a rule outside media (first match)

--- a/test/matchers/toHaveStyleRule.spec.js
+++ b/test/matchers/toHaveStyleRule.spec.js
@@ -41,6 +41,10 @@ const Button = styled.button`
     &:hover {
       color: purple;
     }
+
+    > *:not(:first-child) {
+      margin-left: 12px;
+    }
   }
 
   @media screen and (max-width: 600px) {
@@ -332,6 +336,21 @@ describe('toHaveStyleRule', () => {
       expected: 'pink',
       received: 'pink',
       selector: 'color',
+    }));
+    expect(result.pass).toBeTruthy();
+
+    result = toHaveStyleRule({
+      component,
+      modifier: '> *:not(:first-child)',
+      media: {
+        type: 'screen',
+        width: '400px',
+      },
+    }, 'margin-left', '12px');
+    expect(result.message).toEqual(getMessage({
+      expected: '12px',
+      received: '12px',
+      selector: 'margin-left',
     }));
     expect(result.pass).toBeTruthy();
   });


### PR DESCRIPTION
- [x] Pull request has tests / docs demo, and is linted.
- [ x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (https://help.github.com/articles/closing-issues-via-commit-messages/).
